### PR TITLE
Bump version numbers on deps, and add in kotlin-mockito for later.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -5,6 +5,11 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 RULES_KOTLIN_VERSION = "porque_no_les_dos"
 MAVEN_REPOSITORY_RULES_VERSION = "1.0-rc4"
 MAVEN_REPOSITORY_RULES_SHA = "57357874e88da816857a8ec1f8e6ffa059161ac26fecdd35202e2488dba72d57"
+KOTLIN_VERSION = "1.2.71"
+KOTLINC_RELEASE = {
+    "urls": ["https://github.com/JetBrains/kotlin/releases/download/v{version}/kotlin-compiler-{version}.zip".format(version = KOTLIN_VERSION)],
+    "sha256": "e48292fdfed42f44230bc01f92ffd17002101d8c5aeedfa3dba3cb29c5b6ea7b",
+}
 
 # Rules and tools repositories
 http_archive(
@@ -25,7 +30,7 @@ http_archive(
 
 # Setup Kotlin
 load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kotlin_repositories", "kt_register_toolchains")
-kotlin_repositories()
+kotlin_repositories(compiler_release = KOTLINC_RELEASE)
 kt_register_toolchains()
 
 
@@ -49,20 +54,24 @@ maven_repository_specification(
         "com.google.auto:auto-common:0.10": { "insecure": True },
         "com.google.code.findbugs:jsr305:3.0.2": { "insecure": True },
         "com.google.code.gson:gson:2.8.1": { "insecure": True },
-        "com.google.dagger:dagger-compiler:2.20": { "insecure": True },
-        "com.google.dagger:dagger-producers:2.20": { "insecure": True },
-        "com.google.dagger:dagger-spi:2.20": { "insecure": True },
-        "com.google.dagger:dagger:2.20": {
+        "com.google.dagger:dagger-compiler:2.21": { "insecure": True },
+        "com.google.dagger:dagger-producers:2.21": { "insecure": True },
+        "com.google.dagger:dagger-spi:2.21": { "insecure": True },
+        "com.google.dagger:dagger:2.21": {
             "insecure": True,
-            "build_snippet": snippets.DAGGER.format(version = "2.20"),
+            "build_snippet": snippets.DAGGER.format(version = "2.21"),
         },
         "com.google.errorprone:error_prone_annotations:2.3.1": { "insecure": True },
         "com.google.errorprone:javac-shaded:9+181-r4173-1": { "insecure": True },
         "com.google.googlejavaformat:google-java-format:1.6": { "insecure": True },
+        "com.google.guava:guava:27.0.1-jre": { "insecure": True },
+        "com.google.guava:failureaccess:1.0.1": { "insecure": True },
+        "com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava": { "insecure": True },
         "com.google.j2objc:j2objc-annotations:1.1": { "insecure": True },
         "com.google.truth:truth:0.42": { "insecure": True },
         "com.googlecode.java-diff-utils:diffutils:1.3.0": { "insecure": True },
         "com.mikesamuel:json-sanitizer:1.1": { "insecure": True },
+        "com.nhaarman:mockito-kotlin:1.6.0": { "insecure": True },
         "com.ryanharter.auto.value:auto-value-gson-annotations:0.8.0": { "insecure": True },
         "com.ryanharter.auto.value:auto-value-gson:0.8.0": { "insecure": True },
         "com.squareup.okhttp:okhttp:2.5.0": { "insecure": True },
@@ -72,14 +81,19 @@ maven_repository_specification(
         "javax.inject:javax.inject:1": { "insecure": True },
         "joda-time:joda-time:2.9.9": { "insecure": True },
         "junit:junit:4.13-beta-1": { "insecure": True },
+        "net.bytebuddy:byte-buddy:1.9.7": { "insecure": True },
+        "net.bytebuddy:byte-buddy-agent:1.9.7": { "insecure": True },
         "org.checkerframework:checker-compat-qual:2.5.3": { "insecure": True },
         "org.checkerframework:checker-qual:2.5.3": { "insecure": True },
         "org.codehaus.mojo:animal-sniffer-annotations:1.14": { "insecure": True },
         "org.easymock:easymock:3.1": { "insecure": True },
-        "org.mockito:mockito-core:1.9.5": { "insecure": True },
-        "org.objenesis:objenesis:1.2": { "insecure": True },
+        "org.jetbrains:annotations:13.0": { "insecure": True },
+        "org.jetbrains.kotlin:kotlin-reflect:%s" % KOTLIN_VERSION: { "insecure": True },
+        "org.jetbrains.kotlin:kotlin-stdlib:%s" % KOTLIN_VERSION: { "insecure": True },
+        "org.jetbrains.kotlin:kotlin-stdlib-common:%s" % KOTLIN_VERSION: { "insecure": True },
+        "org.mockito:mockito-core:2.24.0": { "insecure": True },
+        "org.objenesis:objenesis:2.6": { "insecure": True },
         "org.hamcrest:hamcrest-core:1.3": { "insecure": True },
-        "com.google.guava:guava:25.1-jre": { "sha256": "6db0c3a244c397429c2e362ea2837c3622d5b68bb95105d37c21c36e5bc70abf" },
     },
     dependency_target_substitutes = {
         "com.google.dagger": {"@maven//com/google/dagger:dagger": "@maven//com/google/dagger:dagger_api"},


### PR DESCRIPTION
Also normalize kotlin versions and kotlinc release zip, to make sure that maven-supplied kotlin-stdlib (required by kotlin-mockito) is guaranteed to be the same as the one supplied by kotlinc during the compilation job. 